### PR TITLE
Add 4 repositories from GitHub organizations

### DIFF
--- a/resources/scadsai.yml
+++ b/resources/scadsai.yml
@@ -989,7 +989,7 @@ resources:
   submission_date: '2025-11-26T11:35:21.822994'
   type: GitHub Repository
   url: https://github.com/jan-forest/autoencodix
-  - authors:
+- authors:
   - Robert Haase
   - github-actions[bot]
   description: ''


### PR DESCRIPTION
Automatically discovered repositories from configured GitHub organizations:

## Organization: ScaDS
https://github.com/ScaDS

* [zenodo-tracking](https://github.com/ScaDS/zenodo-tracking) - 2 stars
* [cicd-ga-scadsai](https://github.com/ScaDS/cicd-ga-scadsai) - 2 stars
* [BIDS-lecture-2025](https://github.com/ScaDS/BIDS-lecture-2025) - 9 stars
* [famous_computer_science_quotes](https://github.com/ScaDS/famous_computer_science_quotes) - 1 stars

## Organization: ScaDSAILLLE
https://github.com/ScaDSAILLLE

